### PR TITLE
Profile対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ make Slack App and get OAuth token.
 
 ## usage
 
-OAuth token set environment variable or command option.
+OAuth token given by one of the following methods.
+
+#### environment variable
 
 ```
 export SLACK_TOKEN="xoxb-XXXXXXXX-XXXXXXX-XXXXXX"
@@ -23,13 +25,29 @@ slack-quickpost \
   --text [TEXT]
 ```
 
-OR
+#### Option
 
 ```
 slack-quickpost \
   --token xoxb-XXXXXXXX-XXXXXXX-XXXXXX \
   --channel [CHANNEL_ID] \
   --text [TEXT]
+```
+
+#### Config file
+
+Save config yaml `~/.config/slack-quickpost/profile-name.yaml
+
+```yaml
+token: xoxb-XXX
+channel: XXX
+```
+
+Provide the profile name using an environment variable(`SLACK_QUICKPOST_PROFILE`) or option.
+
+```
+SLACK_QUICKPOST_PROFILE=profile-name slack-quickpost --text [TEXT]
+slack-quickpost --profile profile-name --text [TEXT]
 ```
 
 ### post text

--- a/config.go
+++ b/config.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"io"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Profile struct {
+	Token   string `yaml:"token"`
+	Channel string `yaml:"channel"`
+}
+
+func parseProfile(filepath string) (*Profile, error) {
+	prf := &Profile{}
+	f, err := os.Open(filepath)
+
+	if err != nil {
+		return prf, err
+	}
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return prf, err
+	}
+
+	if err := yaml.Unmarshal(data, prf); err != nil {
+		return prf, err
+	}
+
+	return prf, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/pkg/errors v0.8.0
 	github.com/slack-go/slack v0.12.2
 	github.com/spf13/pflag v1.0.5
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
 	gopkg.in/yaml.v2 v2.2.4 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,5 @@ require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
 	gopkg.in/yaml.v2 v2.2.4 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -27,3 +27,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -12,8 +12,6 @@ github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/slack-go/slack v0.8.2 h1:D7jNu0AInBfdQ4QyKPtVSp+ZxQes3EzWW17RZ/va4JE=
-github.com/slack-go/slack v0.8.2/go.mod h1:FGqNzJBmxIsZURAxh2a8D21AnOVvvXZvGligs4npPUM=
 github.com/slack-go/slack v0.12.2 h1:x3OppyMyGIbbiyFhsBmpf9pwkUzMhthJMRNmNlA4LaQ=
 github.com/slack-go/slack v0.12.2/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -23,6 +21,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=

--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	profileName := strGetFirstOne(envProfile, *optProfile)
+	profileName := strGetFirstOne(*optProfile, envProfile)
 
 	var profile = &Profile{}
 	if profileName != "" {
@@ -127,12 +127,12 @@ func main() {
 		}
 	}
 
-	opts.token = strGetFirstOne(profile.Token, envToken, *optToken)
+	opts.token = strGetFirstOne(*optToken, envToken, profile.Token)
 	if opts.token == "" {
 		errText = append(errText, "error: slack token is required")
 	}
 
-	opts.postOpts.channel = strGetFirstOne(profile.Channel, *optChannel)
+	opts.postOpts.channel = strGetFirstOne(*optChannel, profile.Channel)
 	if opts.postOpts.channel == "" {
 		errText = append(errText, "error: channel is required")
 	}

--- a/test.sh
+++ b/test.sh
@@ -4,15 +4,25 @@ set -xeu
 binpath="/tmp/slack-quickpost-bin"
 go build -o $binpath ./...
 
-slackToken=$SLACK_QUICKPOST_TEST_TOKEN
-channelID=$SLACK_QUICKPOST_TEST_CHANNEL_ID
+testProfile=test-profile
+slackToken=$(yq '.token' ~/.config/slack-quickpost/${testProfile}.yaml)
+channelID=$(yq '.channel' ~/.config/slack-quickpost/${testProfile}.yaml)
 iconUrl="https://user-images.githubusercontent.com/10419053/132874304-3c6397b5-e084-4476-a376-e3c7a941039c.png"
 
 # print version
 $binpath --version
 
-# text / token given as option
 unset SLACK_TOKEN
+# token and channel given by Profile
+$binpath --profile ${testProfile} \
+    --text "case: token and channel given profile" \
+
+export SLACK_QUICKPOST_PROFILE=${testProfile}
+$binpath \
+    --text "case: token and channel given profile 2" \
+unset SLACK_QUICKPOST_PROFILE
+
+# text / token given as option
 $binpath --channel $channelID \
     --text "case: token given command option, username and icon not given" \
     --token="${slackToken}"


### PR DESCRIPTION
#10 

`SLACK_QUICKPOST_PROFILE`が空文字列でない、あるいは`--profile`が指定されている場合、`~/.config/slack-quickpost/[profile名].yaml`の中のToken,Channelを利用する

```yaml
token: xoxb-...
channel: C...
```