### PR TITLE
--blockでBlockKitに対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ slack-quickpost \
   --channel [CANNEL_ID] \
   --text [TEXT] \
   --snippet
+
+# post BlockKit
+slack-quickpost \
+  --channel [CANNEL_ID] \
+  --block '{"type":"section","text":{"type":"mrkdwn","text":"*Sample BlockKit"}}'
 ```
 
 ### post file
@@ -84,14 +89,18 @@ slack-quickpost \
 ## comamnd options
 
 ```
---channel string    post slack channel id
---file string       post file path
---icon string       icon emoji
---icon-url string   icon image url
---snippet           post text as snippet
---text string       post text
---textfile string   post text file path
---token string      slack app OAuth token
---username string   user name
---version           print version
+--block string       post block json
+--channel string     post slack channel id
+--file string        post file path
+--icon string        icon emoji
+--icon-url string    icon image url
+--nofail             always return success code(0)
+--profile string     slack quickpost profile name
+--snippet            post text as snippet
+--text string        post text
+--textfile string    post text file path
+--thread-ts string   post under thread
+--token string       slack app OAuth token
+--username string    user name
+--version            print version
 ```

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ slack-quickpost \
 ## comamnd options
 
 ```
---block string       post block json
+--blocks string      post BlockKit json
 --channel string     post slack channel id
 --file string        post file path
 --icon string        icon emoji

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ type Options struct {
 	token    string
 	text     string
 	filepath string
+	block    string
 
 	mode        string
 	snippetMode bool
@@ -75,6 +76,9 @@ func main() {
 
 		// mode: post file
 		filepath = flag.String("file", "", "post file path")
+
+		// mode: post block json
+		optBlock = flag.String("block", "", "post block json")
 
 		// must options
 		envToken   = os.Getenv("SLACK_TOKEN")
@@ -142,6 +146,9 @@ func main() {
 	case *optText != "":
 		opts.text = strings.Replace(*optText, "\\n", "\n", -1)
 		opts.mode = "text"
+	case *optBlock != "":
+		opts.block = *optBlock
+		opts.mode = "block"
 	case *optTextFile != "":
 		bytes, err := ioutil.ReadFile(*optTextFile)
 		if err != nil {
@@ -212,6 +219,16 @@ func Do(opts *Options) (*CliOutput, error) {
 				return nil, errors.Wrap(err, "error: postMessage")
 			}
 		}
+	case "block":
+		blocks := slack.Blocks{}
+		if err := blocks.UnmarshalJSON([]byte(opts.block)); err != nil {
+			return nil, errors.Wrap(err, "error: failed blocks.UnmarshalJSON")
+		}
+		output, err = postBlocks(opts.slackClient, opts.postOpts, blocks)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error postBlocks %s", opts.filepath)
+		}
+
 	case "file":
 		if opts.filepath != "" {
 			file, err := os.Open(opts.filepath)
@@ -267,6 +284,26 @@ func postMessage(client SlackClient, postOpts *PostOptions, text string) (*CliOu
 		Timestamp: ts,
 	}
 
+	return output, nil
+}
+
+func postBlocks(client SlackClient, postOpts *PostOptions, blocks slack.Blocks) (*CliOutput, error) {
+	opts := []slack.MsgOption{}
+	opts = append(opts, postOpts.getMsgOptions()...)
+	opts = append(opts, slack.MsgOptionBlocks(blocks.BlockSet...))
+
+	postedChannel, ts, err := client.PostMessage(
+		postOpts.channel,
+		opts...,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "error postMessage")
+	}
+
+	output := &CliOutput{
+		Channel:   postedChannel,
+		Timestamp: ts,
+	}
 	return output, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ type Options struct {
 	token    string
 	text     string
 	filepath string
-	block    string
+	blocks   string
 
 	mode        string
 	snippetMode bool
@@ -77,8 +77,8 @@ func main() {
 		// mode: post file
 		filepath = flag.String("file", "", "post file path")
 
-		// mode: post block json
-		optBlock = flag.String("block", "", "post block json")
+		// mode: post blocks json
+		optBlocks = flag.String("blocks", "", "post BlockKit json")
 
 		// must options
 		envToken   = os.Getenv("SLACK_TOKEN")
@@ -146,9 +146,9 @@ func main() {
 	case *optText != "":
 		opts.text = strings.Replace(*optText, "\\n", "\n", -1)
 		opts.mode = "text"
-	case *optBlock != "":
-		opts.block = *optBlock
-		opts.mode = "block"
+	case *optBlocks != "":
+		opts.blocks = *optBlocks
+		opts.mode = "blocks"
 	case *optTextFile != "":
 		bytes, err := ioutil.ReadFile(*optTextFile)
 		if err != nil {
@@ -219,9 +219,9 @@ func Do(opts *Options) (*CliOutput, error) {
 				return nil, errors.Wrap(err, "error: postMessage")
 			}
 		}
-	case "block":
+	case "blocks":
 		blocks := slack.Blocks{}
-		if err := blocks.UnmarshalJSON([]byte(opts.block)); err != nil {
+		if err := blocks.UnmarshalJSON([]byte(opts.blocks)); err != nil {
 			return nil, errors.Wrap(err, "error: failed blocks.UnmarshalJSON")
 		}
 		output, err = postBlocks(opts.slackClient, opts.postOpts, blocks)

--- a/test.sh
+++ b/test.sh
@@ -69,3 +69,9 @@ $binpath --channel $channelID  \
     --username "ignored username" \
     --icon "cry" \
     --file /tmp/slack-quickpost-test.jpg
+
+# BlockKit json
+$binpath --channel $channelID  \
+    --username "BlockKit json" \
+    --icon "blush" \
+    --blocks '[{"type":"section","text":{"type":"mrkdwn","text":"*Post BlockKit*"}}]'


### PR DESCRIPTION
``` % export SLACK_QUICKPOST_PROFILE=alterneko-times
 % go run ./... --block '[{"type":"section","text":{"type":"mrkdwn","text":"*slack-quickpostがBlockKitに対応しました*"}}]'
{"channel":"XXX","timestamp":"1697708361.797199"}
```

![image](https://github.com/ToshihitoKon/slack-quickpost/assets/10419053/d04ca83a-4381-40d1-852f-098530f9cbd9)

