### PR TITLE
switch to UploadFileV2()

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -16,6 +16,7 @@ func TestDo(t *testing.T) {
 		text        string
 		mode        string
 		snippetMode bool
+		filepath    string
 		expect      expect
 	}{
 		{
@@ -48,18 +49,28 @@ func TestDo(t *testing.T) {
 				contentType: "file",
 			},
 		},
+		{
+			title:       "upload file",
+			snippetMode: true,
+			mode:        "file",
+			filepath:    "tests/upload.txt",
+			expect: expect{
+				success:     true,
+				contentType: "file",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.title, func(t *testing.T) {
-			client := NewSlackClientMock()
+			client := NewSlackMockClient()
 			opts := &Options{
 				slackClient: client,
 				text:        tt.text,
 				mode:        tt.mode,
 
 				token:       "testtoken",
-				filepath:    "test filepath",
+				filepath:    tt.filepath,
 				snippetMode: tt.snippetMode,
 				postOpts: &PostOptions{
 					username:  "test username",
@@ -69,7 +80,7 @@ func TestDo(t *testing.T) {
 				},
 			}
 
-			err := Do(opts)
+			_, err := Do(opts)
 			if err != nil && tt.expect.success {
 				t.Errorf("error: Do %s", err.Error())
 			}

--- a/slack.go
+++ b/slack.go
@@ -5,7 +5,7 @@ import (
 )
 
 type SlackClient interface {
-	UploadFile(slack.FileUploadParameters) (*slack.File, error)
+	UploadFileV2(slack.UploadFileV2Parameters) (*slack.FileSummary, error)
 	PostMessage(string, ...slack.MsgOption) (string, string, error)
 }
 
@@ -17,11 +17,12 @@ func NewSlackMockClient() *SlackMockClient {
 	return &SlackMockClient{}
 }
 
-func (smc *SlackMockClient) UploadFile(_ slack.FileUploadParameters) (*slack.File, error) {
+func (smc *SlackMockClient) UploadFileV2(_ slack.UploadFileV2Parameters) (*slack.FileSummary, error) {
 	smc.ContentType = "file"
 	// TODO
 	return nil, nil
 }
+
 func (smc *SlackMockClient) PostMessage(_ string, opts ...slack.MsgOption) (string, string, error) {
 	smc.ContentType = "message"
 	// TODO

--- a/tests/upload.txt
+++ b/tests/upload.txt
@@ -1,0 +1,1 @@
+Hello world!


### PR DESCRIPTION
Hi!

Slack's `files.upload` API retires in March 2025.
https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay

switch from UploadFile() to UploadFileV2() method.